### PR TITLE
add css to break line of "long markup code"

### DIFF
--- a/client/src/components/ProposalsPage.js
+++ b/client/src/components/ProposalsPage.js
@@ -36,7 +36,7 @@ const SpeakerVertical = ({ speaker }) => {
 const Proposal = (props) => {
   const { proposal, speakers, isSmallScreen, attended, attendProposal, user} = props;
   const { _id, title, type, tags, abstract } = proposal;
-  return <Row className={cn({ 'mb-8 mx-3 pt-3 bg-gray-200': isSmallScreen })}>
+  return <Row className={cn({ 'proposal mb-8 mx-3 pt-3 bg-gray-200': isSmallScreen })}>
     <Col xs="12" sm={{ size: 7, offset: 1 }} className="mb-6 mb-sm-12">
       <Link className="unstyled-link" to={`/session/${getHref(proposal)}`}><h4>{title}</h4></Link>
       <Row className="d-flex font-size-sm" noGutters>

--- a/client/src/sass/_general.scss
+++ b/client/src/sass/_general.scss
@@ -163,3 +163,8 @@ a.unstyled-link:active {
 .p-relative {
   position: relative;
 }
+
+
+.proposal pre code {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
Fix request from email: Tal Kellner
Long code text on mobile: "tl;dr: smaller app size == growth win"
with this fix it will break it to new line:
result:
"tl;dr: smaller app size == growth 
win"
